### PR TITLE
(GH-6) use https resolution for chocolatey.org

### DIFF
--- a/DSCResources/cChocoInstaller/cChocoInstaller.psm1
+++ b/DSCResources/cChocoInstaller/cChocoInstaller.psm1
@@ -195,7 +195,7 @@ function global:Write-Host
 # ==============================================================================
 
 # variables
-$url = "http://chocolatey.org/api/v2/package/chocolatey/"
+$url = "https://chocolatey.org/api/v2/package/chocolatey/"
 $chocTempDir = Join-Path $env:TEMP "chocolatey"
 $tempDir = Join-Path $chocTempDir "chocInstall"
 if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}
@@ -223,10 +223,10 @@ function InstallChoco
     # download 7zip
     Write-verbose "Download 7Zip commandline tool"
     $7zaExe = Join-Path $tempDir '7za.exe'
-    
-    Download-File 'http://chocolatey.org/7za.exe' "$7zaExe"
-    
-    
+
+    Download-File 'https://chocolatey.org/7za.exe' "$7zaExe"
+
+
     # unzip the package
     Write-verbose "Extracting $file to $tempDir..."
     Start-Process "$7zaExe" -ArgumentList "x -o`"$tempDir`" -y `"$file`"" -Wait

--- a/readme.md
+++ b/readme.md
@@ -5,4 +5,4 @@ This resource is aimed at getting and installing packages from the choco gallery
 
 The resource takes the name of the package and will then install that package. 
 
-See list of packages here: https://chocolatey.org/packages/git.install
+See list of packages here: https://chocolatey.org/packages


### PR DESCRIPTION
At one point we were not able to address SSL for Windows 2003 due to
SNI, but that changed sometime in 2014 when we moved Chocolatey.org to
dedicated servers and IP addresses.

Closes #6
