### PR TITLE
Add version to existence check, add source parameter

### DIFF
--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
@@ -4,4 +4,5 @@ class cChocoPackageInstall : OMI_BaseResource
   [Key] string Name;
   [write] string Params;
   [write] string Version;
+  [write] string Source;
 };


### PR DESCRIPTION
If version parameter is supplied to cChocoPackageInstall, check for existence of the package includes
version test.

Added source parameter to .mof. 

If source parameter is supplied to cChocoPackageInstall, choco source command is executed to get
package from specified source.
