### PR TITLE
Fix issue when using install path containing spaces

### DIFF
--- a/DSCResources/cChocoInstaller/cChocoInstaller.psm1
+++ b/DSCResources/cChocoInstaller/cChocoInstaller.psm1
@@ -250,15 +250,15 @@ function InstallChoco
     Write-verbose 'tools folder:'
     Write-verbose $toolsPath
     Write-verbose 'install folder:' 
-    Write-verbose  $installFolder
-    if ((Test-Path  $installFolder))
+    Write-verbose  '$installFolder'
+    if ((Test-Path  '$installFolder'))
     {
         Write-verbose 'install folder already exists at $installFolder'
     }
     else
     {
         #Write-verbose 'creating install folder at $installFolder'
-        New-Item -ItemType directory -Path $installFolder
+        New-Item -ItemType directory -Path '$installFolder'
     }
     Set-Location $toolsPath
     # ensure module loading preference is on
@@ -269,7 +269,7 @@ function InstallChoco
     remove-module `$moduleName -ErrorAction SilentlyContinue;
     import-module -name  `$psm1File;
     }
-    Initialize-Chocolatey -chocolateyPath $installFolder
+    Initialize-Chocolatey -chocolateyPath '$installFolder'
     "
 
 


### PR DESCRIPTION
Added single quotes to instances of $installFolder to fix issue when using install path with spaces

I was getting errors when trying to install Chocolatey to a file path with spaces in it because it was treating the part of the file path after the space as another argument.  

Hope this pull request is okay, I've never done one before!
