### PR TITLE
Adding 'Ensure' resource property and composite resource

### DIFF
--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
@@ -2,6 +2,7 @@
 class cChocoPackageInstall : OMI_BaseResource
 {
   [Key] string Name;
+  [Write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] String Ensure;
   [write] string Params;
   [write] string Version;
   [write] string Source;

--- a/DSCResources/cChocoPackageInstallSet/cChocoPackageInstallSet.psm1
+++ b/DSCResources/cChocoPackageInstallSet/cChocoPackageInstallSet.psm1
@@ -1,0 +1,43 @@
+Configuration cChocoPackageInstallSet
+{
+<#
+.SYNOPSIS
+Composite DSC Resource allowing you to specify multiple choco packages in a single resource block.
+#>
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String[]]
+        $Name,
+        [ValidateSet('Present','Absent')]
+        [System.String]
+        $Ensure='Present',
+		[parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Source
+    )
+
+    $addSource = $Source
+
+    foreach ($pName in $Name) {
+        ## We only need to specify the source one time,
+        ## so we do it only with the first package
+        if ($addSource) {
+            cChocoPackageInstall "cChocoPackageInstall_$pName" {
+                Ensure = $Ensure
+                Name = $pName
+                Source = $Source
+            }
+            $addSource = $null
+        }
+        else {
+            cChocoPackageInstall "cChocoPackageInstall_$pName" {
+                Ensure = $Ensure
+                Name = $pName
+            }
+        }
+    }
+}

--- a/DSCResources/cChocoPackageInstallerSet/cChocoPackageInstallerSet.psd1
+++ b/DSCResources/cChocoPackageInstallerSet/cChocoPackageInstallerSet.psd1
@@ -1,0 +1,94 @@
+﻿#
+# Module manifest for module 'cChocoPackageInstallerSet'
+#
+# Generated on: 2016/05/11
+#
+
+@{
+
+# Script module or binary module file associated with this manifest.
+RootModule = 'cChocoPackageInstallerSet.schema.psm1'
+
+# Version number of this module.
+ModuleVersion = '2.1.0.0'
+
+# ID used to uniquely identify this module
+GUID = '028ba992-9429-4a6b-9c99-17eb4999cb23'
+
+# Author of this module
+Author = 'Lawrence Gripper'
+
+# Company or vendor of this module
+CompanyName = 'Lawrence Gripper'
+
+# Copyright statement for this module
+Copyright = '(c) 2013-2016 Lawrence Gripper. All rights reserved.'
+
+# Description of the functionality provided by this module
+# Description = 'Allows install/uninstall of a group of choco packages.'
+
+# Minimum version of the Windows PowerShell engine required by this module
+# PowerShellVersion = ''
+
+# Name of the Windows PowerShell host required by this module
+# PowerShellHostName = ''
+
+# Minimum version of the Windows PowerShell host required by this module
+# PowerShellHostVersion = ''
+
+# Minimum version of Microsoft .NET Framework required by this module
+# DotNetFrameworkVersion = ''
+
+# Minimum version of the common language runtime (CLR) required by this module
+# CLRVersion = ''
+
+# Processor architecture (None, X86, Amd64) required by this module
+# ProcessorArchitecture = ''
+
+# Modules that must be imported into the global environment prior to importing this module
+# RequiredModules = @()
+
+# Assemblies that must be loaded prior to importing this module
+# RequiredAssemblies = @()
+
+# Script files (.ps1) that are run in the caller's environment prior to importing this module.
+# ScriptsToProcess = @()
+
+# Type files (.ps1xml) to be loaded when importing this module
+# TypesToProcess = @()
+
+# Format files (.ps1xml) to be loaded when importing this module
+# FormatsToProcess = @()
+
+# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+# NestedModules = @()
+
+# Functions to export from this module
+FunctionsToExport = '*'
+
+# Cmdlets to export from this module
+CmdletsToExport = '*'
+
+# Variables to export from this module
+VariablesToExport = '*'
+
+# Aliases to export from this module
+AliasesToExport = '*'
+
+# List of all modules packaged with this module
+# ModuleList = @()
+
+# List of all files packaged with this module
+# FileList = @()
+
+# Private data to pass to the module specified in RootModule/ModuleToProcess
+# PrivateData = ''
+
+# HelpInfo URI of this module
+# HelpInfoURI = ''
+
+# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+# DefaultCommandPrefix = ''
+
+}
+

--- a/DSCResources/cChocoPackageInstallerSet/cChocoPackageInstallerSet.schema.psm1
+++ b/DSCResources/cChocoPackageInstallerSet/cChocoPackageInstallerSet.schema.psm1
@@ -1,4 +1,4 @@
-Configuration cChocoPackageInstallSet
+Configuration cChocoPackageInstallerSet
 {
 <#
 .SYNOPSIS
@@ -26,7 +26,7 @@ Composite DSC Resource allowing you to specify multiple choco packages in a sing
         ## We only need to specify the source one time,
         ## so we do it only with the first package
         if ($addSource) {
-            cChocoPackageInstall "cChocoPackageInstall_$pName" {
+            cChocoPackageInstaller "cChocoPackageInstaller_$($Ensure)_$($pName)" {
                 Ensure = $Ensure
                 Name = $pName
                 Source = $Source
@@ -34,7 +34,7 @@ Composite DSC Resource allowing you to specify multiple choco packages in a sing
             $addSource = $null
         }
         else {
-            cChocoPackageInstall "cChocoPackageInstall_$pName" {
+            cChocoPackageInstaller "cChocoPackageInstaller_$($Ensure)_$($pName)" {
                 Ensure = $Ensure
                 Name = $pName
             }

--- a/ExampleConfig.ps1
+++ b/ExampleConfig.ps1
@@ -15,6 +15,7 @@
       {
         Name = "googlechrome"
         DependsOn = "[cChocoInstaller]installChoco"
+		
       }
       cChocoPackageInstaller installAtomSpecificVersion
       {
@@ -24,8 +25,35 @@
       }
       cChocoPackageInstaller installGit
       {
+         Ensure = 'Present'
          Name = "git"
          Params = "/Someparam "
+         DependsOn = "[cChocoInstaller]installChoco"
+      }
+      cChocoPackageInstaller noFlashAllowed
+      {
+         Ensure = 'Absent'
+         Name = "flashplayerplugin"
+         DependsOn = "[cChocoInstaller]installChoco"
+      }
+      cChocoPackageInstallerSet installSomeStuff
+      {
+         Ensure = 'Present'
+         Name = @(
+			"git"
+			"skype"
+			"7zip"
+		)
+         DependsOn = "[cChocoInstaller]installChoco"
+      }
+      cChocoPackageInstallerSet stuffToBeRemoved
+      {
+         Ensure = 'Absent'
+         Name = @(
+			"vlc"
+			"ruby"
+			"adobeair"
+		)
          DependsOn = "[cChocoInstaller]installChoco"
       }
    }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: 2.1.0.{build}
 os: WMF 5
 install:
   - ps: Get-PackageProvider -Name NuGet -Force

--- a/cChoco.psd1
+++ b/cChoco.psd1
@@ -1,5 +1,5 @@
 @{
-	Copyright = "(c) 2013 Lawrence Gripper, All rights reserved."; 
+	Copyright = "(c) 2013-2016 Lawrence Gripper, All rights reserved."; 
 	Description = "Module with DSC Resources for using Chocolatey http://chocolatey.org/"; 
 	CompanyName = "Lawrence Gripper"; 
 	GUID = "4857229F-8C2D-41BB-A068-9E3C0C8ED63D"; 
@@ -8,5 +8,5 @@
 	CLRVersion = "4.0"; 
 	CmdletsToExport = "*"; 
 	Author = "Lawrence Gripper"; 
-	ModuleVersion = "2.0.5.22"
+	ModuleVersion = "2.1.0.0"
 }

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ This resource is aimed at getting and installing packages from the choco gallery
 
 The resource takes the name of the package and will then install that package. 
 
-See [ExampleConfig.ps1] for example usage.
+See [ExampleConfig.ps1](ExampleConfig.ps1) for example usage.
 
 See list of packages here: https://chocolatey.org/packages
 

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,8 @@ This resource is aimed at getting and installing packages from the choco gallery
 
 The resource takes the name of the package and will then install that package. 
 
+See [ExampleConfig.ps1](blob/master/ExampleConfig.ps1) for example usage.
+
 See list of packages here: https://chocolatey.org/packages
 
 Contributing

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ This resource is aimed at getting and installing packages from the choco gallery
 
 The resource takes the name of the package and will then install that package. 
 
-See [ExampleConfig.ps1](blob/master/ExampleConfig.ps1) for example usage.
+See [ExampleConfig.ps1] for example usage.
 
 See list of packages here: https://chocolatey.org/packages
 


### PR DESCRIPTION
- `Ensure` resource property makes this resource more consistent with other similar types such as `WindowsFeature` and adds the ability to exclude certain choco packages from being installed (at least not for too long).
- Also added a composite resource `cChocoPackageInstallerSet` which allows you to define a collection of multiple choco packages to install (or uninstall).  Again this is in keeping with the conventions of similar resources that offer a _bulk item_ variation such as the new [`WindowsFeatureSet`](https://msdn.microsoft.com/en-us/powershell/wmf/dsc_newresources) that was added in WMF 5.0.

Please note:
- I've only tested this on WMF 5.0 environment
- I've bumped up the version details to what I thought was logically next and synched up the version info in a few places.
