### PR TITLE
CheckChocoInstalled in Test-TargetResource fails if Chocolatey is not installed

### DIFF
--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -127,7 +127,7 @@ function Test-TargetResource
     Write-Verbose "Start Test-TargetResource"
 
     if (-Not (CheckChocoInstalled)) {
-        retuirn $false
+        return $false
     }
 
     $isInstalled = IsPackageInstalled $Name


### PR DESCRIPTION
CheckChocoInstalled has "retuirn" $false instead of "return" $false
