### PR TITLE
Add an alternate URL path for the chocolatey NuPkg download

### DIFF
--- a/DSCResources/cChocoInstaller/cChocoInstaller.psm1
+++ b/DSCResources/cChocoInstaller/cChocoInstaller.psm1
@@ -49,7 +49,10 @@ function Set-TargetResource
         [parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $ChocoInstallScriptUrl = "https://chocolatey.org/install.ps1"
+        $ChocoInstallScriptUrl = "https://chocolatey.org/install.ps1",
+        [parameter(Mandatory = $false)]
+        [System.String]
+        $ChocoDownloadUrl
     )
     Write-Verbose " Start Set-TargetResource"
     
@@ -63,6 +66,9 @@ function Set-TargetResource
         }
         $file = Join-Path $InstallDir "install.ps1"
         [Environment]::SetEnvironmentVariable("ChocolateyInstall", $InstallDir, [EnvironmentVariableTarget]::Machine)
+        if ($ChocoDownloadUrl) {
+            [Environment]::SetEnvironmentVariable("ChocolateyDownloadUrl", $ChocoDownloadUrl, [System.EnvironmentVariableTarget]::Machine)
+        }
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine")        
         
         $env:ChocolateyInstall = $InstallDir
@@ -95,7 +101,10 @@ function Test-TargetResource
         [parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $ChocoInstallScriptUrl = "https://chocolatey.org/install.ps1"
+        $ChocoInstallScriptUrl = "https://chocolatey.org/install.ps1",
+        [parameter(Mandatory = $false)]
+        [System.String]
+        $ChocoDownloadUrl
     )
 
     Write-Verbose " Start Test-TargetResource"

--- a/DSCResources/cChocoInstaller/cChocoInstaller.psm1
+++ b/DSCResources/cChocoInstaller/cChocoInstaller.psm1
@@ -11,7 +11,10 @@ function Get-TargetResource
         [parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $ChocoInstallScriptUrl = "https://chocolatey.org/install.ps1"
+        $ChocoInstallScriptUrl = "https://chocolatey.org/install.ps1",
+        [parameter(Mandatory = $false)]
+        [System.String]
+        $ChocoDownloadUrl
 
     )
     Write-Verbose " Start Get-TargetResource"
@@ -22,6 +25,7 @@ function Get-TargetResource
     $Configuration = @{
         InstallDir = $env:ChocolateyInstall
         ChocoInstallScriptUrl = $ChocoInstallScriptUrl
+        ChocoDownloadUrl = $ChocoDownloadUrl
     }
 
     if (-not (IsChocoInstalled))


### PR DESCRIPTION
The standard chocolateyInstall.ps1 script has the capability to alter the URL from which the Chocolatey NuPkg is downloaded.  This feature adds an additional property that allows administrators to specify the aforementioned URL.
