### PR TITLE
Feature/allow empty checksums 

### DIFF
--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -22,7 +22,8 @@ function Get-TargetResource
         $Source,
         [parameter(Mandatory = $false)]
         [bool]
-        $AllowEmptyChecksums=$false    )
+        $AllowEmptyChecksums=$false    
+    )
 
     Write-Verbose "Start Get-TargetResource"
 

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -19,8 +19,10 @@ function Get-TargetResource
 		[parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $Source
-    )
+        $Source,
+        [parameter(Mandatory = $false)]
+        [bool]
+        $AllowEmptyChecksums=$false    )
 
     Write-Verbose "Start Get-TargetResource"
 
@@ -35,6 +37,7 @@ function Get-TargetResource
         Params = $Params
         Version = $Version
 		Source = $Source
+        AllowEmptyChecksums = $AllowEmptyChecksums
     }
 
     return $Configuration
@@ -63,8 +66,10 @@ function Set-TargetResource
 		[parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $Source
-
+        $Source,
+        [parameter(Mandatory = $false)]
+        [bool]
+        $AllowEmptyChecksums=$false
     )
     Write-Verbose "Start Set-TargetResource"
 	
@@ -89,7 +94,7 @@ function Set-TargetResource
 			    ($Version) -and -not ($isInstalledVersion) `
 	    )
         {
-            InstallPackage -pName $Name -pParams $Params -pVersion $Version
+            InstallPackage -pName $Name -pParams $Params -pVersion $Version -allowEmptyChecksums $AllowEmptyChecksums
         }
     }
     elseif ($isInstalled) {
@@ -121,7 +126,10 @@ function Test-TargetResource
 		[parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $Source
+        $Source,
+        [parameter(Mandatory = $false)]
+        [bool]
+        $AllowEmptyChecksums=$false
     )
 
     Write-Verbose "Start Test-TargetResource"
@@ -170,22 +178,50 @@ function InstallPackage
     if ((-not ($pParams)) -and (-not $pVersion))
     {
         Write-Verbose "Installing Package Standard"
-        $packageInstallOuput = choco install $pName -y
+        if ($AllowEmptyChecksums -eq $true)
+        {
+            $packageInstallOuput = choco install $pName -y --allowEmptyChecksums
+        }
+        else
+        {
+            $packageInstallOuput = choco install $pName -y
+        }    
     }
     elseif ($pParams -and $pVersion)
     {
         Write-Verbose "Installing Package with Params $pParams and Version $pVersion"
-        $packageInstallOuput = choco install $pName --params="$pParams" --version=$pVersion -y        
+        if ($AllowEmptyChecksums -eq $true)
+        {
+            $packageInstallOuput = choco install $pName --params="$pParams" --version=$pVersion -y --allowEmptyChecksums     
+        }
+        else
+        {
+            $packageInstallOuput = choco install $pName --params="$pParams" --version=$pVersion -y    
+        }
     }
     elseif ($pParams)
     {
         Write-Verbose "Installing Package with params $pParams"
-        $packageInstallOuput = choco install $pName --params="$pParams" -y            
+        if ($AllowEmptyChecksums -eq $true)
+        {
+            $packageInstallOuput = choco install $pName --params="$pParams" -y --allowEmptyChecksums
+        }
+        else
+        {
+            $packageInstallOuput = choco install $pName --params="$pParams" -y 
+        }
     }
     elseif ($pVersion)
     {
         Write-Verbose "Installing Package with version $pVersion"
-        $packageInstallOuput = choco install $pName --version=$pVersion -y        
+        if ($AllowEmptyChecksums -eq $true)
+        {
+            $packageInstallOuput = choco install $pName --version=$pVersion -y 
+        }
+        else
+        {
+            $packageInstallOuput = choco install $pName --version=$pVersion -y 
+        }
     }
     
     

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
@@ -6,4 +6,5 @@ class cChocoPackageInstall : OMI_BaseResource
   [write] string Params;
   [write] string Version;
   [write] string Source;
+  [write] boolean AllowEmptyChecksums;
 };

--- a/DSCResources/cChocoPackageInstallerSet/cChocoPackageInstallerSet.schema.psm1
+++ b/DSCResources/cChocoPackageInstallerSet/cChocoPackageInstallerSet.schema.psm1
@@ -17,8 +17,10 @@ Composite DSC Resource allowing you to specify multiple choco packages in a sing
 		[parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $Source
-    )
+        $Source,
+        [parameter(Mandatory = $false)]
+        [bool]
+        $AllowEmptyChecksums=$false    )
 
     $addSource = $Source
 
@@ -30,6 +32,7 @@ Composite DSC Resource allowing you to specify multiple choco packages in a sing
                 Ensure = $Ensure
                 Name = $pName
                 Source = $Source
+                AllowEmptyChecksums = $AllowEmptyChecksums
             }
             $addSource = $null
         }
@@ -37,6 +40,7 @@ Composite DSC Resource allowing you to specify multiple choco packages in a sing
             cChocoPackageInstaller "cChocoPackageInstaller_$($Ensure)_$($pName)" {
                 Ensure = $Ensure
                 Name = $pName
+                AllowEmptyChecksums = $AllowEmptyChecksums
             }
         }
     }

--- a/ExampleConfig.ps1
+++ b/ExampleConfig.ps1
@@ -30,6 +30,12 @@
          Params = "/Someparam "
          DependsOn = "[cChocoInstaller]installChoco"
       }
+      cChocoPackageInstaller installGitChocoEmptyChecksum
+      {
+          Ensure = 'Present'
+          Name = 'git'
+          AllowEmptyChecksums = $true #This property is only valid for chocolatey v0.10.0 or later.
+      }
       cChocoPackageInstaller noFlashAllowed
       {
          Ensure = 'Absent'


### PR DESCRIPTION
Addresses issue #45 

Adds a DSC property which allows the user to specify the --allowEmptyChecksums parameter on the chocolatey install command.
