### PR TITLE
added priority validation to test

### DIFF
--- a/DSCResources/cChocoSource/cChocoSource.psm1
+++ b/DSCResources/cChocoSource/cChocoSource.psm1
@@ -142,8 +142,15 @@ function Test-TargetResource
 	foreach($chocosource in $sources)
 	{
 		if($chocosource.id -eq $name -and $ensure -eq 'Present')
-		{		
-			return $true
+		{
+            if ($chocosource.priority -eq $Priority)
+            {
+                return $true
+            }
+            else
+            {
+                return $false
+            }
 		}
 		elseif($chocosource.id -eq $name -and $ensure -eq 'Absent')
 		{


### PR DESCRIPTION
Evaluate priority of source when it's already is configured. If priority mismatch, resource is not in desired stated. Set will correct the drift without modification.
solves #63 