### PR TITLE
Make the match end in .config

### DIFF
--- a/DSCResources/cChocoSource/cChocoSource.psm1
+++ b/DSCResources/cChocoSource/cChocoSource.psm1
@@ -134,7 +134,7 @@ function Test-TargetResource
 		$chocofolder = $env:ChocolateyInstall
 	}
 	$configfolder = "$chocofolder\config"
-	$configfile = Get-ChildItem $configfolder | Where-Object {$_.Name -match "chocolatey.config"}
+	$configfile = Get-ChildItem $configfolder | Where-Object {$_.Name -match "chocolatey.config$"}
 
 	$xml = [xml](Get-Content $configfile.FullName)
 	$sources = $xml.chocolatey.sources.source


### PR DESCRIPTION
Since Chocolatey nowadays creates a *.config.backup file, the filter was to wide. I narrowed it down so that it will result in a single result and prevent issues such as:

Cannot convert value "System.Object[]" to type "System.Xml.XmlDocument".