### PR TITLE
(GH-72) PowerShell scripts in format for signing

### DIFF
--- a/DSCResources/cChocoInstaller/cChocoInstaller.psm1
+++ b/DSCResources/cChocoInstaller/cChocoInstaller.psm1
@@ -1,4 +1,4 @@
-function Get-TargetResource
+﻿function Get-TargetResource
 {
     [OutputType([hashtable])]
     param

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -1,4 +1,4 @@
-function Get-TargetResource
+﻿function Get-TargetResource
 {
     [OutputType([hashtable])]
     param

--- a/DSCResources/cChocoPackageInstallerSet/cChocoPackageInstallerSet.schema.psm1
+++ b/DSCResources/cChocoPackageInstallerSet/cChocoPackageInstallerSet.schema.psm1
@@ -1,4 +1,4 @@
-Configuration cChocoPackageInstallerSet
+﻿Configuration cChocoPackageInstallerSet
 {
 <#
 .SYNOPSIS
@@ -14,7 +14,7 @@ Composite DSC Resource allowing you to specify multiple choco packages in a sing
         [ValidateSet('Present','Absent')]
         [System.String]
         $Ensure='Present',
-		[parameter(Mandatory = $false)]
+        [parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Source

--- a/DSCResources/cChocoSource/cChocoSource.psm1
+++ b/DSCResources/cChocoSource/cChocoSource.psm1
@@ -1,4 +1,4 @@
-function Get-TargetResource
+﻿function Get-TargetResource
 {
     [CmdletBinding()] 
     [OutputType([System.Collections.Hashtable])]

--- a/cChoco.psd1
+++ b/cChoco.psd1
@@ -1,4 +1,4 @@
-@{
+﻿@{
 	Copyright         = "(c) 2017 Chocolatey Software, (c) 2013-2017 Lawrence Gripper, All rights reserved.";
 	Description       = "Chocolatey DSC Resources for use with internal packages and the community package repository. Learn more at http://chocolatey.org/";
 	CompanyName       = "Chocolatey Software";


### PR DESCRIPTION
PowerShell can not validate authenticode signatures for files that are
UTF8 without BOM, nor can they for files with LF line endings as
signatures end up creating mixed mode files. For those reasons, the
files need to be UTF-8 with a BOM and Windows line endings (CRLF).

Closes #72