### PR TITLE
(GH-77) Push to gallery on new tags

### DIFF
--- a/AppVeyor/AppVeyorDeploy.ps1
+++ b/AppVeyor/AppVeyorDeploy.ps1
@@ -18,7 +18,7 @@ Write-Host "Updating module manifest to version: $env:APPVEYOR_BUILD_VERSION"
 # Publish to PS Gallery           #
 #---------------------------------#
 
-if ( ($env:APPVEYOR_REPO_NAME -notmatch 'chocolatey') -or ($env:APPVEYOR_REPO_BRANCH -notmatch 'master') )
+if ( ($env:APPVEYOR_REPO_NAME -notmatch 'chocolatey') -or (!$env:APPVEYOR_REPO_TAG_NAME) )
 {
     Write-Host "Finished testing of branch: $env:APPVEYOR_REPO_BRANCH - Exiting"
     exit;

--- a/AppVeyor/AppVeyorDeploy.ps1
+++ b/AppVeyor/AppVeyorDeploy.ps1
@@ -1,11 +1,11 @@
-﻿#---------------------------------# 
-# Header                          # 
-#---------------------------------# 
+﻿#---------------------------------#
+# Header                          #
+#---------------------------------#
 Write-Host 'Running AppVeyor deploy script' -ForegroundColor Yellow
 
-#---------------------------------# 
-# Update module manifest          # 
-#---------------------------------# 
+#---------------------------------#
+# Update module manifest          #
+#---------------------------------#
 Write-Host 'Creating new module manifest'
 
 $ModuleManifestPath = Join-Path -path "$pwd" -ChildPath ("$env:ModuleName"+'.psd1')
@@ -14,9 +14,9 @@ $ModuleManifest     = Get-Content $ModuleManifestPath -Raw
 Write-Host "Updating module manifest to version: $env:APPVEYOR_BUILD_VERSION"
 [regex]::replace($ModuleManifest,'(ModuleVersion = )(.*)',"`$1'$env:APPVEYOR_BUILD_VERSION'") | Out-File -LiteralPath $ModuleManifestPath
 
-#---------------------------------# 
-# Publish to PS Gallery           # 
-#---------------------------------# 
+#---------------------------------#
+# Publish to PS Gallery           #
+#---------------------------------#
 
 if ( ($env:APPVEYOR_REPO_NAME -notmatch 'chocolatey') -or ($env:APPVEYOR_REPO_BRANCH -notmatch 'master') )
 {

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Here's the general process of fixing an issue in the DSC Resource Kit:
 Build and Publishing
 ============================
 
-AppVeyor is used to package up the resource and publish to the Powershell Gallery (on successful build from master branch only). 
+AppVeyor is used to package up the resource and publish to the Powershell Gallery (on successful build from a newly pushed tag only).
 
 The AppVeyor scripts do the following:
 - Test the resources using 'xDSCResourceDesigner'

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Community Chocolatey DSC Resource
 
 This resource is aimed at getting and installing packages from the choco gallery.
 
-The resource takes the name of the package and will then install that package. 
+The resource takes the name of the package and will then install that package.
 
 See [ExampleConfig.ps1](ExampleConfig.ps1) for example usage.
 
@@ -19,23 +19,23 @@ See list of packages here: https://chocolatey.org/packages
 Contributing
 =============================
 
-Happy to accept new features and fixes. Outstanding issues which can be worked on tagged HelpedWanted under issues. 
+Happy to accept new features and fixes. Outstanding issues which can be worked on tagged HelpedWanted under issues.
 
 Submitting a PR
 =============================
 
-Here's the general process of fixing an issue in the DSC Resource Kit:  
-1. Fork the repository.  
-3. Clone your fork to your machine.  
-4. It's preferred to create a non-master working branch where you store updates.  
-5. Make changes.  
-6. Write pester tests to ensure that the issue is fixed.  
-7. Submit a pull request to the development branch.  
-8. Make sure all tests are passing in AppVeyor for your pull request.  
-9. Make sure your code does not contain merge conflicts.  
-10. Address comments (if any). 
+Here's the general process of fixing an issue in the DSC Resource Kit:
+1. Fork the repository.
+3. Clone your fork to your machine.
+4. It's preferred to create a non-master working branch where you store updates.
+5. Make changes.
+6. Write pester tests to ensure that the issue is fixed.
+7. Submit a pull request to the development branch.
+8. Make sure all tests are passing in AppVeyor for your pull request.
+9. Make sure your code does not contain merge conflicts.
+10. Address comments (if any).
 
-Build and Publishing 
+Build and Publishing
 ============================
 
 AppVeyor is used to package up the resource and publish to the Powershell Gallery (on successful build from master branch only). 


### PR DESCRIPTION
Instead of pushing on merges to master, push to the PowerShell gallery
on new tags being added. We want to use tagging for versioning and
getting to version history in the repository, so it's good to just set
that up appropriately.

Closes #77