### PR TITLE
(GH-85) Pass the source to cChocoPackageInstallerSet correctly

### DIFF
--- a/DSCResources/cChocoPackageInstallerSet/cChocoPackageInstallerSet.schema.psm1
+++ b/DSCResources/cChocoPackageInstallerSet/cChocoPackageInstallerSet.schema.psm1
@@ -20,24 +20,11 @@ Composite DSC Resource allowing you to specify multiple choco packages in a sing
         $Source
     )
 
-    $addSource = $Source
-
     foreach ($pName in $Name) {
-        ## We only need to specify the source one time,
-        ## so we do it only with the first package
-        if ($addSource) {
-            cChocoPackageInstaller "cChocoPackageInstaller_$($Ensure)_$($pName)" {
-                Ensure = $Ensure
-                Name = $pName
-                Source = $Source
-            }
-            $addSource = $null
-        }
-        else {
-            cChocoPackageInstaller "cChocoPackageInstaller_$($Ensure)_$($pName)" {
-                Ensure = $Ensure
-                Name = $pName
-            }
+        cChocoPackageInstaller "cChocoPackageInstaller_$($Ensure)_$($pName)" {
+            Ensure = $Ensure
+            Name = $pName
+            Source = $Source
         }
     }
 }


### PR DESCRIPTION
The cChocoPackageInstallerSet resource only provides the Source
parameter to the first package being installed. This occurred due to
historical reasons where the Source would be added to the system
rather than being specified.

This commit will pass the Source in for every package.