### PR TITLE
(GH-87) Moved to using limited output.

### DIFF
--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -381,14 +381,7 @@ Function Upgrade-Package {
 }
 
 function Get-ChocoInstalledPackage {
-    $res = choco list -lo | ForEach-Object {
-        $Obj = $_ -split '\s'
-        [pscustomobject]@{
-            'Name'    = $Obj[0]
-            'Version' = $Obj[1]     
-        }
-    }
-    Return $res
+    Return (choco list -lo -r | ConvertFrom-Csv -Header 'Name', 'Version' -Delimiter "|")
 }
 
 Export-ModuleMember -Function *-TargetResource


### PR DESCRIPTION
Old implementation caused promotional message, and chocolatey banner to get mixed into the works. If upgrading Chocolatey, cause problems as the version caught is a string with "vX.X.X" and in the where clause is attempted to be converted to a .net version type. 

Limiting the output reduces it to only the packages, leaving out any banners.

Spent a while thinking of how to test this, as point 5 states - but nothing could come to mind without mocking the call to choco and writing its own response, at least from what I can think of. 

An example of the fixes below


```
<#

PS C:\Users\lg\Documents\Git\cChoco> choco list -lo
Chocolatey v0.10.7
chocolatey 0.10.7
erlang 19.3
rabbitmq 3.6.10
3 packages installed.


#>


 function Get-ChocoInstalledPackage {
    $res = choco list -lo | ForEach-Object {
        $Obj = $_ -split '\s'
        [pscustomobject]@{
            'Name'    = $Obj[0]
            'Version' = $Obj[1]     
        }
    }
    Return $res
    

 }

 Get-ChocoInstalledPackage

 <#

 Name       Version 
----       ------- 
Chocolatey v0.10.7 
chocolatey 0.10.7  
erlang     19.3    
rabbitmq   3.6.10  
3          packages


 #>

 function Get-ChocoInstalledPackage {

 Return (choco list -lo -r | ConvertFrom-Csv -Header 'Name', 'Version' -Delimiter "|")

 }

 Get-ChocoInstalledPackage

 <#

 Name       Version
----       -------
chocolatey 0.10.7 
erlang     19.3   
rabbitmq   3.6.10

 #>

```

Closes #87.