### PR TITLE
Choco Run Errors out because of Null Source

### DIFF
--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -69,7 +69,6 @@ function Set-TargetResource
         [ValidateNotNullOrEmpty()]
         [string]
         $Version,
-        [ValidateNotNullOrEmpty()]
         [string]
         $Source,
         [String]
@@ -134,7 +133,6 @@ function Test-TargetResource
         [ValidateNotNullOrEmpty()]
         [string]
         $Version,
-        [ValidateNotNullOrEmpty()]
         [string]
         $Source,
         [ValidateNotNullOrEmpty()]
@@ -167,7 +165,10 @@ function Test-TargetResource
         Write-Verbose -Message "Checking if $Name is installed"
 
         if ($AutoUpgrade -and $isInstalled) {
-            $result = Test-LatestVersionInstalled -pName $Name -pSource $Source
+            if ($Source){
+                [string]$pSource = "-pSource `"$Source`""
+            }
+            $result = Test-LatestVersionInstalled -pName $Name $pSource
         } else {
             $result = $isInstalled
         }
@@ -320,7 +321,6 @@ Function Test-LatestVersionInstalled {
     param(
         [Parameter(Mandatory)]
         [string]$pName,
-        [Parameter(Mandatory)]
         [string]$pSource
     )
     Write-Verbose -Message "Testing if $pName can be upgraded"


### PR DESCRIPTION
Fixes #96 
Removed unnecessary [ValidateNotNullOrEmpty] requirements on $Source parameter
Added check to only add source if set when calling Test-TargetResource

I did not edit the cChocoPackageInstallerSet\cChocoPackageInstallerSet.schema.psm1 to remove
the source parameter from the MOF as its presence in the MOF does not cause any problems, 
and the composite resources do not appear to allow dynamically building the schema based
on which parameters are defined, so each potentially Null variable combination would require an
if/else and specifying the full schema which would get messy.