### PR TITLE
(GH-83) Turn off download progress

### DIFF
--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -240,7 +240,7 @@ function InstallPackage
         $chocoParams += " $cParams"
     }
     # Check if Chocolatey version is Greater than 0.10.4, and add --no-progress 
-    if ((Get-ChocoVersion) -ge [version]('0.10.4')){
+    if ((Get-ChocoVersion) -ge [System.Version]('0.10.4')){
         $chocoParams += " --no-progress"
     }
 
@@ -276,7 +276,7 @@ function UninstallPackage
         $chocoParams += " --version=`"$pVersion`""
     }
     # Check if Chocolatey version is Greater than 0.10.4, and add --no-progress 
-    if ((Get-ChocoVersion) -ge [version]('0.10.4')){
+    if ((Get-ChocoVersion) -ge [System.Version]('0.10.4')){
         $chocoParams += " --no-progress"
     }
 
@@ -401,7 +401,7 @@ Function Upgrade-Package {
         $chocoParams += " $cParams"
     }
     # Check if Chocolatey version is Greater than 0.10.4, and add --no-progress 
-    if ((Get-ChocoVersion) -ge [version]('0.10.4')){
+    if ((Get-ChocoVersion) -ge [System.Version]('0.10.4')){
         $chocoParams += " --no-progress"
     }
 
@@ -458,7 +458,7 @@ function Get-ChocoVersion ($action) {
             $res = Import-Clixml $chocoVersion
         } else {
             $cmd = choco -v
-            $res = [version]($cmd.Split('-')[0])
+            $res = [System.Version]($cmd.Split('-')[0])
             $res | Export-Clixml -Path $chocoVersion
         }
     }

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -433,7 +433,10 @@ function Get-ChocoInstalledPackage {
     }
     $ChocoInstallList = Join-Path -Path $ChocoInstallLP -ChildPath 'ChocoInstalled.xml'
 
-    if ( -not $Purge) {
+    if ($Purge) {
+        Remove-Item $ChocoInstallList -Force
+        $res = $true
+    } else {
         $PackageCacheSec = (Get-Date).AddSeconds('-60')
         if ( $PackageCacheSec -lt (Get-Item $ChocoInstallList -ErrorAction SilentlyContinue).LastWriteTime ) {
                 $res = Import-Clixml $ChocoInstallList
@@ -443,9 +446,6 @@ function Get-ChocoInstalledPackage {
                 $res | Export-Clixml -Path $ChocoInstallList
             }
         }
-    } else {
-        Remove-Item $ChocoInstallList -Force
-        $res = $true
     }
 
     Return $res
@@ -465,6 +465,9 @@ function Get-ChocoVersion {
     $chocoVersion = Join-Path -Path $chocoInstallCache -ChildPath 'ChocoVersion.xml'
 
     if ( -not $Purge) {
+        Remove-Item $chocoVersion -Force
+        $res = $true
+    } else {
         $cacheSec = (Get-Date).AddSeconds('-60')
         if ( $cacheSec -lt (Get-Item $chocoVersion -ErrorAction SilentlyContinue).LastWriteTime ) {
             $res = Import-Clixml $chocoVersion
@@ -473,9 +476,6 @@ function Get-ChocoVersion {
             $res = [System.Version]($cmd.Split('-')[0])
             $res | Export-Clixml -Path $chocoVersion
         }
-    } else {
-        Remove-Item $chocoVersion -Force
-        $res = $true
     }
     Return $res
 }

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -433,7 +433,7 @@ function Get-ChocoInstalledPackage {
     }
     $ChocoInstallList = Join-Path -Path $ChocoInstallLP -ChildPath 'ChocoInstalled.xml'
 
-    if ($Purge) {
+    if ($Purge.IsPresent) {
         Remove-Item $ChocoInstallList -Force
         $res = $true
     } else {
@@ -464,7 +464,7 @@ function Get-ChocoVersion {
     }
     $chocoVersion = Join-Path -Path $chocoInstallCache -ChildPath 'ChocoVersion.xml'
 
-    if ( -not $Purge) {
+    if ($Purge.IsPresent) {
         Remove-Item $chocoVersion -Force
         $res = $true
     } else {

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -259,6 +259,7 @@ function InstallPackage
 
 function UninstallPackage
 {
+    [Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingInvokeExpression','')]
     param(
         [Parameter(Position=0,Mandatory)]
         [string]$pName,

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -455,9 +455,11 @@ function Get-ChocoVersion ($action) {
     } else {
         $cacheSec = (Get-Date).AddSeconds('-60')
         if ( $cacheSec -lt (Get-Item $chocoVersion -ErrorAction SilentlyContinue).LastWriteTime ) {
-                $res = Import-Clixml $chocoVersion
+            $res = Import-Clixml $chocoVersion
         } else {
-            $res = [version](choco -v) | Export-Clixml -Path $chocoVersion
+            $cmd = choco -v
+            $res = [version]($cmd.Split('-')[0])
+            $res | Export-Clixml -Path $chocoVersion
         }
     }
 

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -241,7 +241,7 @@ function InstallPackage
     }
     # Check if Chocolatey version is Greater than 0.10.4, and add --no-progress 
     $chocoVer = [system.version](Get-ChocoInstalledPackage | Where-Object { $_.name -eq 'chocolatey' }).Version
-    if ($chocoVer -ge 0.10.4) {
+    if ($chocoVer -ge '0.10.4') {
         $chocoParams += " --no-progress"
     }
 
@@ -278,7 +278,7 @@ function UninstallPackage
     }
     # Check if Chocolatey version is Greater than 0.10.4, and add --no-progress 
     $chocoVer = [system.version](Get-ChocoInstalledPackage | Where-Object { $_.name -eq 'chocolatey' }).Version
-    if ($chocoVer -ge 0.10.4) {
+    if ($chocoVer -ge '0.10.4') {
         $chocoParams += " --no-progress"
     }
 
@@ -404,7 +404,7 @@ Function Upgrade-Package {
     }
     # Check if Chocolatey version is Greater than 0.10.4, and add --no-progress 
     $chocoVer = [system.version](Get-ChocoInstalledPackage | Where-Object { $_.name -eq 'chocolatey' }).Version
-    if ($chocoVer -ge 0.10.4) {
+    if ($chocoVer -ge '0.10.4') {
         $chocoParams += " --no-progress"
     }
 


### PR DESCRIPTION
Fixes Issue #83 "Turn off download progress"
Choco Versions >10.4 overwhelm log with download Progress data

Added Check for Choco version and add "--no-progress" to the Params list
 - Renamed Params variable for consistency across functions
 - Updated Choco comand execution formatting to be consistent across functions