### PR TITLE
Fixing $env:ChocolateyInstall when is empty

### DIFF
--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -405,6 +405,8 @@ Function Upgrade-Package {
 }
 
 function Get-ChocoInstalledPackage ($action) {
+    $env:ChocolateyInstall = Split-Path -parent (Get-Command choco.exe).Source
+    
     $ChocoInstallLP = Join-Path -Path $env:ChocolateyInstall -ChildPath 'cache'
     if ( -not (Test-Path $ChocoInstallLP)){
         New-Item -Name 'cache' -Path $env:ChocolateyInstall -ItemType Directory | Out-Null


### PR DESCRIPTION
I'm facing an issue to use the cChoco install package DSC because for some reason the $env:ChocolateyInstall variable is empty. Therefore, I added a line to dynamically get the choco.exe sourcedue the $env:ChocolateyInstall is empty.

#130 