### PR TITLE
(GH-117) Support specifying minimum package version

### DIFF
--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -221,7 +221,7 @@ function Test-ChocoInstalled
     Write-Verbose -Message 'Test-ChocoInstalled'
     $env:Path = [Environment]::GetEnvironmentVariable('Path','Machine')
 
-    #Write-Verbose -Message "Env:Path contains: $env:Path"
+    Write-Verbose -Message "Env:Path contains: $env:Path"
     if (Test-Command -command choco)
     {
         Write-Verbose -Message 'YES - Choco is Installed'
@@ -337,6 +337,7 @@ function UninstallPackage
 function IsPackageInstalled
 {
     [CmdletBinding(DefaultParameterSetName = 'RequiredVersion')]
+    [OutputType([bool])]
     param(
         [Parameter(Position=0, Mandatory)]
         [string]$pName,
@@ -350,7 +351,7 @@ function IsPackageInstalled
     Write-Verbose -Message "Start IsPackageInstalled $pName"
 
     $env:Path = [Environment]::GetEnvironmentVariable('Path','Machine')
-    #Write-Verbose -Message "Path variables: $env:Path"
+    Write-Verbose -Message "Path variables: $env:Path"
 
     $installedPackages = Get-ChocoInstalledPackage
 
@@ -447,7 +448,7 @@ Function Upgrade-Package {
     )
 
     $env:Path = [Environment]::GetEnvironmentVariable('Path','Machine')
-    #Write-Verbose -Message "Path variables: $env:Path"
+    Write-Verbose -Message "Path variables: $env:Path"
 
     [string]$chocoParams = '-dv -y'
     if ($pParams) {

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -367,9 +367,12 @@ function IsPackageInstalled
         if ($pre) {
             throw "MinimumVersion does not support comparing pre-releases, please use Version parameter instead"
         }
+
         $comparablePackages = $installedPackages | Where-Object { $_.Name -eq $pName} | ForEach-Object {
-            # ignoring pre-release as per above comment
-            $v = [System.Version](($_.Version -split "-")[0])
+            # as mentioned above we cant convert prerelease versions to [Sytem.Version] so we ignore anything after "-"
+            # leaving just the . seperated numeric version. this is loosely equivalent to "rounding down"
+            $parseableVersion = ($_.Version -split "-")[0]
+            $v = [System.Version]($parseableVersion)
             $_ | Add-Member -MemberType NoteProperty -Name ComparableVersion -Value $v -PassThru
         }
         $installedPackages = $comparablePackages | Where-Object {$_.ComparableVersion -ge $pMinimumVersion}

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -123,8 +123,8 @@ function Set-TargetResource
                     InstallPackage -pName $Name -pParams $Params -pVersion $versionToInstall -pSource $Source -cParams $chocoParams
                 }
                 elseif ($MinimumVersion) {
-                    Write-Verbose -Message "Upgrading $Name becuase installed version is lower that the specified minimum"
-                    $chocoParams += " --version '$versionToInstall'"
+                    Write-Verbose -Message "Upgrading $Name because installed version is lower that the specified minimum"
+                    $chocoParams += " --version='$versionToInstall'"
                     Upgrade-Package -pName $Name -pParams $Params -pSource $Source -cParams $chocoParams
                 }
                 elseif ($AutoUpgrade) {
@@ -337,7 +337,7 @@ function UninstallPackage
 function IsPackageInstalled
 {
     [CmdletBinding(DefaultParameterSetName = 'RequiredVersion')]
-    [OutputType([bool])]
+    [OutputType([Boolean])]
     param(
         [Parameter(Position=0, Mandatory)]
         [string]$pName,
@@ -351,7 +351,7 @@ function IsPackageInstalled
     Write-Verbose -Message "Start IsPackageInstalled $pName"
 
     $env:Path = [Environment]::GetEnvironmentVariable('Path','Machine')
-    Write-Verbose -Message "Path variables: $env:Path"
+    #Write-Verbose -Message "Path variables: $env:Path"
 
     $installedPackages = Get-ChocoInstalledPackage
 
@@ -384,7 +384,6 @@ function IsPackageInstalled
 
     return $false
 }
-
 
 Function Test-LatestVersionInstalled {
     [Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingInvokeExpression','')]
@@ -448,7 +447,7 @@ Function Upgrade-Package {
     )
 
     $env:Path = [Environment]::GetEnvironmentVariable('Path','Machine')
-    Write-Verbose -Message "Path variables: $env:Path"
+    #Write-Verbose -Message "Path variables: $env:Path"
 
     [string]$chocoParams = '-dv -y'
     if ($pParams) {
@@ -494,7 +493,7 @@ function Get-ChocoInstalledPackage {
     $ChocoInstallList = Join-Path -Path $ChocoInstallLP -ChildPath 'ChocoInstalled.xml'
 
     if ($Purge.IsPresent) {
-        Remove-Item $ChocoInstallList -Force -ErrorAction SilentlyContinue
+        Remove-Item $ChocoInstallList -Force
         $res = $true
     } else {
         $PackageCacheSec = (Get-Date).AddSeconds('-60')

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
@@ -5,6 +5,7 @@ class cChocoPackageInstall : OMI_BaseResource
   [Write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] String Ensure;
   [write] string Params;
   [write] string Version;
+  [write] string MinimumVersion;
   [write] string Source;
   [Write] String chocoParams;
   [Write] Boolean AutoUpgrade;

--- a/Tests/cChocoPackageInstall_Tests.ps1
+++ b/Tests/cChocoPackageInstall_Tests.ps1
@@ -160,6 +160,35 @@ Describe -Name "Testing $ResourceName loaded from $ResourceFile" -Fixture {
             Test-TargetResource @Scenario6 | Should Be $false
         }
     }
+
+    Context -Name "Package is installed with prerelease version 1.0.0-1" -Fixture {
+        Mock -CommandName 'Get-ChocoInstalledPackage' -ModuleName 'cChocoPackageInstall' -MockWith {
+            return [pscustomobject]@{
+                'Name'    = 'GoogleChrome'
+                'Version' = '1.0.0-1'
+            }
+        }
+
+        $Scenario1 = @{
+            Name    = 'GoogleChrome'
+            Ensure  = 'Present'
+            MinimumVersion = '0.9.0'
+        }
+
+        It -name "Test-TargetResource -ensure 'Present' -MinimumVersion '0.9.0' should return True" -test {
+            Test-TargetResource @Scenario1 | Should Be $true
+        }
+
+        $Scenario2 = @{
+            Name    = 'GoogleChrome'
+            Ensure  = 'Present'
+            MinimumVersion = '1.0.1'
+        }
+
+        It -name "Test-TargetResource -ensure 'Present' -MinimumVersion '1.0.1' should return False" -test {
+            Test-TargetResource @Scenario2 | Should Be $false
+        }
+    }
 }
 
 #Clean-up

--- a/Tests/cChocoPackageInstall_Tests.ps1
+++ b/Tests/cChocoPackageInstall_Tests.ps1
@@ -76,6 +76,24 @@ Describe -Name "Testing $ResourceName loaded from $ResourceFile" -Fixture {
         It -name "Test-TargetResource -ensure 'Absent' -version '1.0.0' -AutoUpgrade should return True" -test {
             Test-TargetResource @Scenario5 | Should Be $True
         }
+
+        $Scenario6 = @{
+            Name        = 'GoogleChrome'
+            Ensure      = 'Absent'
+            MinimumVersion     = '1.0'
+        }
+        It -name "Test-TargetResource -ensure 'Absent' -MinimumVersion '1.0' should return True" -test {
+            Test-TargetResource @Scenario6 | Should Be $True
+        }
+
+        $Scenario7 = @{
+            Name           = 'GoogleChrome'
+            Ensure         = 'Present'
+            MinimumVersion = '1.0'
+        }
+        It -name "Test-TargetResource -ensure 'Present' -MinimumVersion '1.0' should return False" -test {
+            Test-TargetResource @Scenario7 | Should Be $false
+        }
     }
 
     Context -Name "Package is installed with version 1.0.0" -Fixture {
@@ -120,6 +138,26 @@ Describe -Name "Testing $ResourceName loaded from $ResourceFile" -Fixture {
 
         It -name "Test-TargetResource -ensure 'Present' -version '1.0.1' should return False" -test {
             Test-TargetResource @Scenario4 | Should Be $False
+        }
+
+        $Scenario5 = @{
+            Name    = 'GoogleChrome'
+            Ensure  = 'Present'
+            MinimumVersion = '0.9.0'
+        }
+
+        It -name "Test-TargetResource -ensure 'Present' -MinimumVersion '0.9.0' should return True" -test {
+            Test-TargetResource @Scenario5 | Should Be $true
+        }
+
+        $Scenario6 = @{
+            Name    = 'GoogleChrome'
+            Ensure  = 'Present'
+            MinimumVersion = '1.0.1'
+        }
+
+        It -name "Test-TargetResource -ensure 'Present' -MinimumVersion '1.0.1' should return False" -test {
+            Test-TargetResource @Scenario6 | Should Be $false
         }
     }
 }

--- a/Tests/cChoco_ScriptAnalyzerTests.ps1
+++ b/Tests/cChoco_ScriptAnalyzerTests.ps1
@@ -30,7 +30,14 @@ if ($Modules.count -gt 0) {
       Context “Testing Module '$($module.FullName)'” {
         foreach ($rule in $rules) {
           It “passes the PSScriptAnalyzer Rule $rule“ {
-            (Invoke-ScriptAnalyzer -Path $module.FullName -IncludeRule $rule.RuleName ).Count | Should Be 0
+            $Failures = Invoke-ScriptAnalyzer -Path $module.FullName -IncludeRule $rule.RuleName
+            $FailuresCount = ($Failures | Measure-Object).Count
+            if ($FailuresCount -gt 0) {
+              $Failures | ForEach-Object {
+                Write-Warning "Script: $($_.ScriptName), Line $($_.Line), Message $($_.Message)"
+              }
+            }
+            $FailuresCount | Should Be 0
           }
         }
       }


### PR DESCRIPTION
As discussed in #117 here is support for specifying a minimum allowed version. Test-TargetResource returns true if the installed package version is greater or equal to that specified. This helps when user are given permission to update to the latest version of apps not yet specified in DSC. 

Originally I had intended to include a MaxmimumVersion also but on reflection I don't have a use case for this so its probably better to not include it for no reason. 

One caveat that i welcome feedback on is that when using MinimumVersion the test is carried out on [System.Version] objects as opposed to strings for the Version parameter. This could be confusing but I didn't want to alter the behaviors of Version as it is an existing feature. Let me know if you have any concerns about this. 