### PR TITLE
(GH-95) Allow for upgrading of packages

### DIFF
--- a/AppVeyor/AppVeyorInstall.ps1
+++ b/AppVeyor/AppVeyorInstall.ps1
@@ -29,8 +29,9 @@ Write-Host "Installed NuGet version '$($pkg.version)'"
 # Install Modules                 #
 #---------------------------------#
 [version]$ScriptAnalyzerVersion = '1.8.1'
+[version]$PesterVersion = '4.10.1'
 Install-Module -Name 'PSScriptAnalyzer' -Repository PSGallery -Force -ErrorAction Stop -MaximumVersion $ScriptAnalyzerVersion
-Install-Module -Name 'Pester' -SkipPublisherCheck -Repository PSGallery -Force -ErrorAction Stop
+Install-Module -Name 'Pester' -SkipPublisherCheck -Repository PSGallery -Force -ErrorAction Stop -MaximumVersion $PesterVersion
 Install-Module -Name 'xDSCResourceDesigner' -Repository PSGallery -Force -ErrorAction Stop
 
 #---------------------------------#

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -486,7 +486,7 @@ function Upgrade-Package {
         $chocoParams += " --params=`"$pParams`""
     }
     if ($pVersion) {
-        $chocoinstallparams += " --version=`"$pVersion`""
+        $chocoupgradeparams += " --version=`"$pVersion`""
     }
     if ($pSource) {
         $chocoParams += " --source=`"$pSource`""

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -486,7 +486,7 @@ function Upgrade-Package {
         $chocoParams += " --params=`"$pParams`""
     }
     if ($pVersion) {
-        $chocoupgradeparams += " --version=`"$pVersion`""
+        $chocoParams += " --version=`"$pVersion`""
     }
     if ($pSource) {
         $chocoParams += " --source=`"$pSource`""

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -80,9 +80,7 @@ function Set-TargetResource
         [String]
         $chocoParams,
         [bool]
-        $AutoUpgrade = $false,
-        [bool]
-        $UpgradeLowerVersion = $false
+        $AutoUpgrade = $false
     )
     Write-Verbose -Message 'Start Set-TargetResource'
     $isVersionPresent = $PSBoundParameters.ContainsKey('Version')
@@ -131,7 +129,7 @@ function Set-TargetResource
                         $canUpgrade = $installedVersion.CompareTo($targetVersion) -le 0
                     }
 
-                    if ($UpgradeLowerVersion -and $canUpgrade) {
+                    if ($canUpgrade) {
                         Write-Verbose -Message "Upgrading $Name to version $Version"
                         Upgrade-Package -pName $Name -pParams $Params -pVersion $Version
                     }
@@ -189,9 +187,7 @@ function Test-TargetResource
         [String]
         $chocoParams,
         [bool]
-        $AutoUpgrade = $false,
-        [bool]
-        $UpgradeLowerVersion = $false
+        $AutoUpgrade = $false
     )
 
     Write-Verbose -Message 'Start Test-TargetResource'

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
@@ -9,5 +9,5 @@ class cChocoPackageInstall : OMI_BaseResource
   [write] string Source;
   [Write] String chocoParams;
   [Write] Boolean AutoUpgrade;
-  [Write] Boolean UpgradeLowerVersions;
+  [Write] Boolean UpgradeLowerVersion;
 };

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
@@ -9,5 +9,4 @@ class cChocoPackageInstall : OMI_BaseResource
   [write] string Source;
   [Write] String chocoParams;
   [Write] Boolean AutoUpgrade;
-  [Write] Boolean UpgradeLowerVersion;
 };

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.schema.mof
@@ -9,4 +9,5 @@ class cChocoPackageInstall : OMI_BaseResource
   [write] string Source;
   [Write] String chocoParams;
   [Write] Boolean AutoUpgrade;
+  [Write] Boolean UpgradeLowerVersions;
 };


### PR DESCRIPTION
This is related to #95 and adds a new resource parameter called `UpgradeLowerVersions` that causes the cChocoPackageInstall resource to call `choco update` instead of executing an uninstall/install when the package is already installed and on a lower version.