### PR TITLE
(GH-149): Allow null/empty for Source param of Get-TargetResource

### DIFF
--- a/DSCResources/cChocoPackageInstallerSet/cChocoPackageInstallerSet.schema.psm1
+++ b/DSCResources/cChocoPackageInstallerSet/cChocoPackageInstallerSet.schema.psm1
@@ -36,10 +36,19 @@ Composite DSC Resource allowing you to specify multiple choco packages in a sing
     )
 
     foreach ($pName in $Name) {
-        cChocoPackageInstaller "cChocoPackageInstaller_$($Ensure)_$($pName)" {
-            Ensure = $Ensure
-            Name = $pName
-            Source = $Source
+        $ResourceName = "cChocoPackageInstaller_$($Ensure)_$($pName)"
+
+        if ($Source) {
+            cChocoPackageInstaller $ResourceName {
+                Ensure = $Ensure
+                Name = $pName
+                Source = $Source
+            }
+        } else {
+            cChocoPackageInstaller $ResourceName {
+                Ensure = $Ensure
+                Name = $pName
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
Not doing so will break `Get-DscConfiguration` when called after applying a configuration with a `cChocoPackageInstallerSet` resource which does not specify the `Source` parameter. This is due to the composite resource unconditionally setting the parameter.

## Related Issue
Fixes #149

## Motivation and Context
Without this fix running `Get-DscConfiguration` will fail in affected configurations.

## How Has This Been Tested?
Internal test environment with an affected configuration.

## Screenshots (if appropriate):
N/A

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.