### PR TITLE
(GH-151) Download install.ps1 to temp folder.

### DIFF
--- a/DSCResources/cChocoInstaller/cChocoInstaller.psm1
+++ b/DSCResources/cChocoInstaller/cChocoInstaller.psm1
@@ -190,7 +190,9 @@ Function Install-Chocolatey {
     Write-Verbose "Env:ChocolateyInstall has $env:ChocolateyInstall"
 
     #Download an execute install script
-    $file = Join-Path -Path $InstallDir -ChildPath 'install.ps1'
+    $tempPath = Join-Path -Path $env:TEMP -ChildPath ([GUID]::NewGuid().ToString())
+    New-Item -Path $tempPath -ItemType Directory | Out-Null
+    $file = Join-Path -Path $tempPath -ChildPath 'install.ps1'
     Get-FileDownload -url $ChocoInstallScriptUrl -file $file
     . $file
 


### PR DESCRIPTION
## Description

Changes to the Chocolatey install.ps1 means that the script can no longer be downloaded to the same folder as Chocolatey is to be installed in.

This changes downloads the Chocolatey install.ps1 to a temp folder before execution.

## Related Issue

Fixes #151

## Motivation and Context
Fixes the bug in issue #151 where Chocolatey will fail to install.

## How Has This Been Tested?
Tested on a Windows 2019 server using the Examples directory code.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
