### PR TITLE
Add test-path handler to cChocoPackageInstall in case of missing ChocoInstalled.xml

### DIFF
--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -507,8 +507,7 @@ function Get-ChocoInstalledPackage {
         if (Test-Path -Path $ChocoInstallList) {
             Write-Verbose "Purging old ChocoInstalled.xml file at $ChocoInstallList"
             Remove-Item $ChocoInstallList -Force
-        }
-        else {
+        } else {
             Write-Verbose "Did not locate ChocoInstalled.xml file to remove at $ChocoInstallList, taking no action"
         }
         $res = $true

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -505,11 +505,11 @@ function Get-ChocoInstalledPackage {
 
     if ($Purge.IsPresent) {
         if (Test-Path -Path $ChocoInstallList) {
-            Write-Verbose "Purging old package cache $ChocoInstallList"
+            Write-Verbose "Purging old ChocoInstalled.xml file at $ChocoInstallList"
             Remove-Item $ChocoInstallList -Force
         }
         else {
-            Write-Verbose "Did not locate package cache to remove at $ChocoInstallList, taking no action"
+            Write-Verbose "Did not locate ChocoInstalled.xml file to remove at $ChocoInstallList, taking no action"
         }
         $res = $true
     } else {

--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -504,7 +504,13 @@ function Get-ChocoInstalledPackage {
     $ChocoInstallList = Join-Path -Path $ChocoInstallLP -ChildPath 'ChocoInstalled.xml'
 
     if ($Purge.IsPresent) {
-        Remove-Item $ChocoInstallList -Force
+        if (Test-Path -Path $ChocoInstallList) {
+            Write-Verbose "Purging old package cache $ChocoInstallList"
+            Remove-Item $ChocoInstallList -Force
+        }
+        else {
+            Write-Verbose "Did not locate package cache to remove at $ChocoInstallList, taking no action"
+        }
         $res = $true
     } else {
         $PackageCacheSec = (Get-Date).AddSeconds('-60')


### PR DESCRIPTION
## Description Of Changes
`cChocoPackageInstall` `Get-ChocoInstalledPackage` has been updated to test for the presence of `ChocoInstalled.xml` before trying to delete it when purge is set to true, avoiding a breaking error if it is not located.

## Motivation and Context
Fixes #160 

## Testing
1. Validated on Windows Server 2019 by creating local cChoco DSC module at new version with applied changes. Resource specified was uninstalled and reinstalled at specific verison (as per report in issue #160 ) with graceful handling of the missing ChocoInstalled.xml file. File was not detected, `remove-item` was skipped, and module run completed successfully.
### Operating Systems Testing
- Windows Server 2019 Core
- Windows Server 2016

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
Fixes #160 