### PR TITLE
[cChocoInstaller] Do not create install dir prior to calling install.ps1 script

### DIFF
--- a/DSCResources/cChocoInstaller/cChocoInstaller.psm1
+++ b/DSCResources/cChocoInstaller/cChocoInstaller.psm1
@@ -183,12 +183,6 @@ Function Install-Chocolatey {
     )
     Write-Verbose 'Install-Chocolatey'
 
-    #Create install directory if it does not exist
-    If(-not (Test-Path -Path $InstallDir)) {
-        Write-Verbose "[ChocoInstaller] Creating $InstallDir"
-        New-Item -Path $InstallDir -ItemType Directory
-    }
-
     #Set permanent EnvironmentVariable
     Write-Verbose 'Setting ChocolateyInstall environment variables'
     [Environment]::SetEnvironmentVariable('ChocolateyInstall', $InstallDir, [EnvironmentVariableTarget]::Machine)


### PR DESCRIPTION
## Description Of Changes
Change `cChocoInstaller` resource to not create the install dir before calling the `install.ps1` file.

## Motivation and Context
Following change in the `install.ps1` file, chocolatey installation will stop if the target installation path exists (even if empty);
Ref: https://github.com/chocolatey/home/issues/276

## Testing
- Run the following DSC configuration with the changed module:
```
Configuration InstallChoco {
    Import-DSCResource -ModuleName cChoco

    cChocoInstaller "ChocoInstall"
    {
        installDir = "C:\ProgramData\chocolatey"
    }
}
```
- Installation is successful

### Operating Systems Testing
- Windows Server 2022

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
    * Not sure of the change scope
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #179 
