### PR TITLE
Flag DSC to reboot computer if package returns a reboot code.

### DIFF
--- a/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
+++ b/DSCResources/cChocoPackageInstall/cChocoPackageInstall.psm1
@@ -294,6 +294,11 @@ function InstallPackage
     $packageInstallOuput = Invoke-Expression -Command $cmd
     Write-Verbose -Message "Package output $packageInstallOuput"
 
+    if ($LASTEXITCODE -in 350,1604) {
+        Write-Verbose -Message "Package has requested a reboot."
+        $global:DSCMachineStatus = 1
+    }
+
     # Clear Package Cache
     Get-ChocoInstalledPackage -Purge
 
@@ -330,6 +335,11 @@ function UninstallPackage
     $packageUninstallOuput = Invoke-Expression -Command $cmd
 
     Write-Verbose -Message "Package uninstall output $packageUninstallOuput "
+
+    if ($LASTEXITCODE -in 350,1604) {
+        Write-Verbose -Message "Package has requested a reboot."
+        $global:DSCMachineStatus = 1
+    }
 
     # Clear Package Cache
     Get-ChocoInstalledPackage -Purge
@@ -489,6 +499,11 @@ Function Upgrade-Package {
 
     $packageUpgradeOuput = Invoke-Expression -Command $cmd
     $packageUpgradeOuput | ForEach-Object { Write-Verbose -Message $_ }
+
+    if ($LASTEXITCODE -in 350,1604) {
+        Write-Verbose -Message "Package has requested a reboot."
+        $global:DSCMachineStatus = 1
+    }
 
     # Clear Package Cache
     Get-ChocoInstalledPackage -Purge


### PR DESCRIPTION
## Description Of Changes
Handle package exit codes 350 and 1604 by setting $global:DSCMachineStatus = 1. DSC interprets this as a request to reboot the computer. If the LocalConfigurationManager has RebootNodeIfNeeded  set, this will cause an immediate reboot after the cChocoPackageInstaller resource has returned. If RebootNodeIfNeeded is not set, DSC will stop and wait for a reboot before continuing.

## Motivation and Context
To indicate that a reboot is required, a package can return a 350 or 1604 exit code when usepackagecodes is set, and that code can be percolated down through dependencies when exitwhenrebootdetected is set (see also chocolatey/choco#1038). Currently DSC doesn't know what to do with those responses. The proposed workaround in issue #25 is to use the PendingReboot resource to detect a generic reboot condition. But this is not always sufficient.  For one, the reboot condition detected may not have anything to do with the cChocoPackageInstall resource. For another, a package may request a reboot but not set any of the standard Windows pending reboot flags. 

In my use case, an internal third-party driver exe installer would uninstall previous instances and return a specific exit code if run when a previous version was already installed. In this case, a reboot is required and the installer must be re-run. Having built the internal Chocolatey package, I honored the specific return code from the exe installer by setting the Chocolatey return code 1604 to indicate a "some work completed prior to reboot request being detected". Because cChoco did not handle these exit codes any differently, DSC marked the resource as being in a desired state and never completed the installation even allowing the attempted installation of other dependent packages. 
 
## Testing
This has been tested internally and in production using an internal package that I do not have the rights to publish to the community repo. 

### Operating Systems Testing
Windows 10 LTSC
Windows 11 23H2

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [X] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [X] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #25
